### PR TITLE
Rewrite and refactor extensively, add AVX/AVX2 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,19 @@
-CC=gcc
-CFLAGS=-O2 -march=native -mtune=native
+override CPPFLAGS += -Iinclude
+CFLAGS += -std=c99
 
-all:
-	$(CC) $(CFLAGS) -Iinclude -o analyze-x86 analyze-x86.c
+PROGS = analyze-x86
+SRCS = $(PROGS:%=%.c)
+DEPS = $(SRCS:%.c=%.d)
+
+DEPEND.c = $(COMPILE.c) -MM -MP
+%.d: %.c
+	$(DEPEND.c) $< $(OUTPUT_OPTION)
+
+all: $(PROGS)
 
 clean:
-	rm analyze-x86
+	rm -f $(PROGS) *.o *.d
+
+.PHONY: all clean
+
+-include $(DEPS)

--- a/include/3dnow.h
+++ b/include/3dnow.h
@@ -19,9 +19,7 @@
  *      MA 02110-1301, USA.
  */
 
-#define NUM3DNOW 24
-
-static char set3dnow [NUM3DNOW] [12] = {
+static const char *set3dnow[] = {
 	"femms",
 	"pavgusb",
 	"pf2id",
@@ -46,4 +44,5 @@ static char set3dnow [NUM3DNOW] [12] = {
 	"pmulhrw",
 	"prefetch",
 	"pswapw",
+	NULL
 };

--- a/include/3dnowext.h
+++ b/include/3dnowext.h
@@ -19,9 +19,7 @@
  *      MA 02110-1301, USA.
  */
 
-#define NUM3DNOWEXT 24
-
-static char set3dnowext [NUM3DNOWEXT] [12] = {
+static const char *set3dnowext[] = {
 	"maskmovq",
 	"movntq",
 	"pavgb",
@@ -46,4 +44,5 @@ static char set3dnowext [NUM3DNOWEXT] [12] = {
 	"pshufw",
 	"pswapd",
 	"sfence",
+	NULL
 };

--- a/include/486.h
+++ b/include/486.h
@@ -19,13 +19,12 @@
  *      MA 02110-1301, USA.
  */
 
-#define NUM486 6
-
-static char set486 [NUM486] [12] = {
+static const char *set486[] = {
 	"bswap",
 	"cmpxchg",
 	"invd",
 	"invlpg",
 	"wbinvd",
 	"xadd",
+	NULL
 };

--- a/include/586.h
+++ b/include/586.h
@@ -19,11 +19,10 @@
  *      MA 02110-1301, USA.
  */
 
-#define NUM586 4
-
-static char set586 [NUM586] [12] = {
+static const char *set586[] = {
 	"cmpxchg8b",
 	"rdmsr",
 	"rdtsc",
 	"wrmsr",
+	NULL
 };

--- a/include/686.h
+++ b/include/686.h
@@ -19,9 +19,7 @@
  *      MA 02110-1301, USA.
  */
 
-#define NUM686 54
-
-static char set686 [NUM686] [12] = {
+static const char *set686[] = {
 	"cmova",
 	"cmovae",
 	"cmovb",
@@ -76,4 +74,5 @@ static char set686 [NUM686] [12] = {
 	"ud2",
 	"ud2a",
 	"ud2b",
+	NULL
 };

--- a/include/aes.h
+++ b/include/aes.h
@@ -19,13 +19,12 @@
  *      MA 02110-1301, USA.
  */
 
-#define NUMAES 7
-
-static char setaes [NUMAES] [16] = {
+static const char *setaes[] = {
 	"aesdec",
 	"aesdeclast",
 	"aesenc",
 	"aesenclast",
 	"aesimc",
-	"aeskeygenassist"
+	"aeskeygenassist",
+	NULL
 };

--- a/include/analyze-x86.h
+++ b/include/analyze-x86.h
@@ -34,3 +34,4 @@
 #include "sse4a.h"
 #include "aes.h"
 #include "pclmul.h"
+#include "avx.h"

--- a/include/avx.h
+++ b/include/avx.h
@@ -1,7 +1,6 @@
 /*      analyze-x86
  *
- *      Copyright 2010 Meya Argenta <fierevere@ya.ru>
- *      Copyright 2012 Alexey Shvetsov <alexxy@gentoo.org>
+ *      Copyright 2016 Ivan Shapovalov <intelfx100@gmail.com>
  *
  *      This program is free software; you can redistribute it and/or modify
  *      it under the terms of the GNU General Public License as published by
@@ -19,12 +18,50 @@
  *      MA 02110-1301, USA.
  */
 
-static const char *setsse4a[] = {
-	"extrq",
-	"insertq",
-	"lzcnt",
-	"movntsd",
-	"movntss",
-	"popcnt",
+static const char *setavx[] = {
+	"vbroadcastss",
+	"vbroadcastsd",
+	"vbroadcastf128",
+	"vinsertf128",
+	"vextractf128",
+	"vmaskmovps",
+	"vmaskmovpd",
+	"vpermilps",
+	"vpermilpd",
+	"vperm2f128",
+	"vzeroall",
+	"vzeroupper",
+	NULL
+};
+
+static const char *setavx2[] = {
+	"vpbroadcastb",
+	"vpbroadcastw",
+	"vpbroadcastd",
+	"vpbroadcastq",
+	"vbroadcasti128",
+	"vinserti128",
+	"vextracti128",
+	"vgatherdpd",
+	"vgatherqpd",
+	"vgatherdps",
+	"vgatherqps",
+	"vpgatherdd",
+	"vpgatherdq",
+	"vpgatherqd",
+	"vpgatherqq",
+	"vpmasqmovd",
+	"vpmasqmovq",
+	"vperms",
+	"vpermd",
+	"vpermpd",
+	"vpermpq",
+	"vperm2i128",
+	"vpblendd",
+	"vpsllvd",
+	"vpsllvq",
+	"vpsrlvd",
+	"vpsrlvq",
+	"vpsravd",
 	NULL
 };

--- a/include/mmx.h
+++ b/include/mmx.h
@@ -19,9 +19,7 @@
  *      MA 02110-1301, USA.
  */
 
-#define NUMMMX 47
-
-static char setmmx [NUMMMX] [12] = {
+static const char *setmmx[] = {
 	"emms",
 	"movd",
 	"movq",
@@ -69,4 +67,5 @@ static char setmmx [NUMMMX] [12] = {
 	"punpckldq",
 	"punpcklwd",
 	"pxor",
+	NULL
 };

--- a/include/pclmul.h
+++ b/include/pclmul.h
@@ -19,8 +19,7 @@
  *      MA 02110-1301, USA.
  */
 
-#define NUMPCLMUL 1
-
-static char setpclmul [NUMPCLMUL] [12] = {
-	"pclmulqdq"
+static const char *setpclmul[] = {
+	"pclmulqdq",
+	NULL
 };

--- a/include/sse.h
+++ b/include/sse.h
@@ -19,9 +19,7 @@
  *      MA 02110-1301, USA.
  */
 
-#define NUMSSE 81
-
-static char setsse [NUMSSE] [12] = {
+static const char *setsse[] = {
 	"addps",
 	"addss",
 	"andnps",
@@ -103,4 +101,5 @@ static char setsse [NUMSSE] [12] = {
 	"unpckhps",
 	"unpcklps",
 	"xorps",
+	NULL
 };

--- a/include/sse2.h
+++ b/include/sse2.h
@@ -19,9 +19,7 @@
  *      MA 02110-1301, USA.
  */
 
-#define NUMSSE2 130
-
-static char setsse2 [NUMSSE2] [12] = {
+static const char *setsse2[] = {
 	"addpd",
 	"addsd",
 	"andnpd",
@@ -152,4 +150,5 @@ static char setsse2 [NUMSSE2] [12] = {
 	"punpckhwd",
 	"punpcklbw",
 	"punpckldq",
+	NULL
 };

--- a/include/sse3.h
+++ b/include/sse3.h
@@ -19,9 +19,7 @@
  *      MA 02110-1301, USA.
  */
 
-#define NUMSSE3 15
-
-static char setsse3 [NUMSSE3] [12] = {
+static const char *setsse3[] = {
 	"addsubpd",
 	"addsubps",
 	"fisttp",
@@ -37,4 +35,5 @@ static char setsse3 [NUMSSE3] [12] = {
 	"movshdup",
 	"movsldup",
 	"mwait",
+	NULL
 };

--- a/include/sse41.h
+++ b/include/sse41.h
@@ -19,9 +19,7 @@
  *      MA 02110-1301, USA.
  */
 
-#define NUMSSE41 49
-
-static char setsse41 [NUMSSE41] [12] = {
+static const char *setsse41[] = {
 	"blendpd",
 	"blendps",
 	"blendvpd",
@@ -71,4 +69,5 @@ static char setsse41 [NUMSSE41] [12] = {
 	"roundps",
 	"roundsd",
 	"roundss",
+	NULL
 };

--- a/include/sse42.h
+++ b/include/sse42.h
@@ -19,9 +19,7 @@
  *      MA 02110-1301, USA.
  */
 
-#define NUMSSE42 7
-
-static char setsse42 [NUMSSE42] [12] = {
+static const char *setsse42[] = {
 	"crc32",
 	"pcmpestri",
 	"pcmpestrm",
@@ -29,4 +27,5 @@ static char setsse42 [NUMSSE42] [12] = {
 	"pcmpistri",
 	"pcmpistrm",
 	"popcnt",
+	NULL
 };

--- a/include/ssse3.h
+++ b/include/ssse3.h
@@ -19,9 +19,7 @@
  *      MA 02110-1301, USA.
  */
 
-#define NUMSSSE3 16
-
-static char setssse3 [NUMSSSE3] [12] = {
+static const char *setssse3[] = {
 	"pabsb",
 	"pabsw",
 	"palignr",
@@ -37,4 +35,5 @@ static char setssse3 [NUMSSSE3] [12] = {
 	"psignb",
 	"psignd",
 	"psignw",
+	NULL
 };


### PR DESCRIPTION
- use tables instead of copy-pasting
- reformat code to match Linux kernel code style
- request disassembly in Intel assembly flavor as our opcode tables do
  not include AT&T-style operand length suffixes (this fixes matching of
  certain classes)
- add AVX/AVX2 support
